### PR TITLE
Save file name on each tracker and header file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7110,6 +7110,14 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "requires": {
+        "truncate-utf8-bytes": "1.0.2"
+      }
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
@@ -7968,6 +7976,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "1.0.4"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -8117,6 +8133,11 @@
           "dev": true
         }
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-dom": "^15.4.2",
     "react-popper": "^0.7.4",
     "react-redux": "^5.0.4",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/src/css/components/_song-editor-container.scss
+++ b/src/css/components/_song-editor-container.scss
@@ -10,19 +10,50 @@
             margin-bottom: 0;
         }
         input {
+            text-transform: none;
             border: 2px solid #594e4e;
             font-size: 11px;
             padding: 3px 4px 4px 4px;
             border-right-width: 0;
+            border-top-left-radius: 4px;
+            border-bottom-left-radius: 4px;
         }
+        
         input + button {
             border-radius: 0;
             margin-right: 0;
             border-right-width: 0;
+            position: relative;
         }
         input + button + button {
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
+            position: relative;
+        }
+        input + button:disabled,
+        input + button + button:disabled {
+            cursor: initial;
+        }
+        input + button:disabled > i,
+        input + button + button:disabled > i {
+            opacity: .5;
+        }
+
+        input + button:hover:before,
+        input + button + button:hover:before {
+            position: absolute;
+            left: 50%;
+            transform: translate(-50%, calc(-100% - 4px));
+            top: 0;
+            color: white;
+            background: #584d4e;
+            padding: 4px 8px;
+            border-radius: 4px;
+            white-space: nowrap;
+        }
+        input + button:hover:before,
+        input + button + button:hover:before {
+            content: attr(data-tooltip);
         }
     }
 

--- a/src/js/components/Loader.js
+++ b/src/js/components/Loader.js
@@ -16,18 +16,21 @@ class LoaderView extends Component {
 
     saveJSON (e) {
 
-        // get fx, tracks, channels
-        const props = this.props
+        // get fx, tracks, channels, and songName
+        const { channels, fx, songName, tracks  } = this.props
         const saveData = {
             fx: props.fx,
             channels: props.channels,
-            tracks: props.tracks
+            tracks: props.tracks,
+            meta: {
+                name: songName
+            }
         }
 
         // make the browser download the file
         const download = document.createElement('a')
         download.href = `data:text/plain;charset=utf-8;base64,${btoa(JSON.stringify(saveData))}`
-        download.download = 'song.atm'
+        download.download = `${songName}.atm`
 
         document.body.appendChild(download)
         download.click()
@@ -65,6 +68,10 @@ class LoaderView extends Component {
                         "channel": JSON.parse(JSON.stringify(result.fx).replace(/val_b/g, 'val_1').replace(/val"/g, 'val_0"')),
                         "track": []
                       }
+                const fileName = file.name.replace('.atm', '')
+                result.meta = result.meta || {}
+                result.meta.name = result.meta.name || fileName
+                console.log(JSON.stringify(result, null, 2))
                 this.props.setLoadedData(result)
             } else {
                 return alert('invalid file (2)')
@@ -84,7 +91,7 @@ class LoaderView extends Component {
 
         const names = Object.getOwnPropertyNames(file)
 
-        if ( names.length === 3 ) truths++
+        if ( names.length === 3 || names.length === 4 ) truths++
 
         for ( const name of names ) {
 
@@ -122,17 +129,18 @@ class LoaderView extends Component {
     }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = ({ channels, fx, songName, tracks }) => {
     return {
-        tracks: state.tracks,
-        channels: state.channels,
-        fx: state.fx
+        channels,
+        fx,
+        songName,
+        tracks
     }
 }
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        setLoadedData ({channels, tracks, fx} = data) {
+        setLoadedData ({channels, tracks, fx, meta} = data) {
             dispatch({
                 type: 'STATUS_SET',
                 status: 1
@@ -162,6 +170,10 @@ const mapDispatchToProps = (dispatch) => {
             dispatch({
                 type: 'STATUS_SET',
                 status: 0
+            })
+            dispatch({
+                type: 'SET_SONG_NAME',
+                songName: meta.name
             })
         }
     }

--- a/src/js/components/editor/drumEditor/DrumEditorView.js
+++ b/src/js/components/editor/drumEditor/DrumEditorView.js
@@ -219,11 +219,9 @@ class DrumEditor extends Component {
                 </div>
 
                 <div className="editor-play-buttons">
-                    {/* <button onClick={this.playOnce}>play once</button> */}
                     <button onClick={ this[playOrStop] }>
                         {`${playOrStopText}`}
                     </button>
-                    {/* <button onClick={this.playSongAndRepeat}>{ `${state.repeatIsOn ? 'stop' : 'play'} repeat` }</button> */}
                     <label>
                         Repeat
                         <input

--- a/src/js/components/editor/songEditor/SongEditor.js
+++ b/src/js/components/editor/songEditor/SongEditor.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux'
 import SongEditorView from './SongEditorView'
 
-const mapStateToProps = (state) => {
-    const { fx, songIsPlaying } = state
-
+const mapStateToProps = ({ fx, songIsPlaying, songName, songState }) => {
     return {
         fxStatus: fx.status,
-        songIsPlaying
+        songIsPlaying,
+        songName,
+        songState
     }
 }
 
@@ -28,6 +28,12 @@ const mapDispatchToProps = (dispatch) => {
             dispatch({
                 type: "TOGGLE_SONG_REPEAT",
                 repeat
+            })
+        },
+        onSongNameChange (e) {
+            dispatch({
+                type: "SET_SONG_NAME",
+                songName: e.target.value
             })
         }
     }

--- a/src/js/components/editor/songEditor/SongEditorView.js
+++ b/src/js/components/editor/songEditor/SongEditorView.js
@@ -90,7 +90,10 @@ class SongEditor extends Component {
 
     render () {
         const state = this.state
-        const { songIsPlaying } = this.props
+        const { onSongNameChange, songIsPlaying, songName } = this.props
+        const defaultTip = 'ENTER A SONG NAME'
+        const saveTip = songName.length ? `SAVE ${songName}.atm` : defaultTip
+        const exportTip = songName.length ? `EXPORT ${songName}.h` : defaultTip
         const playOrStop = songIsPlaying ? 'stopSong' : 'playSong'
         const playOrStopText = songIsPlaying ? 'Stop' : 'Play'
         const { fxStatus, toggleSongRepeat } = this.props
@@ -100,12 +103,32 @@ class SongEditor extends Component {
                 <h5>
                     Song editor
                     <div style={{flex: 1}}></div>
-                    <input id="song-title" placeholder="song title..." />
-                    <button onClick={ this.saveJSON }>
-                        <i className="fa fa-save" aria-hidden="true"></i>
+                    <input
+                        value={songName}
+                        onChange={onSongNameChange}
+                        id="song-title"
+                        placeholder="song title..."
+                    />
+                    <button
+                        onClick={ this.saveJSON }
+                        disabled={!songName.length}
+                        data-tooltip={saveTip}
+                    >
+                        <i
+                            className="fa fa-save"
+                            aria-hidden="true"
+                        />
                     </button>
-                    <button onClick={ this.exportSong }>
-                        <i className="fa fa-download" aria-hidden="true"></i>
+                    <button
+                        onClick={ this.exportSong }
+                        disabled={!songName.length}
+                        data-tooltip={exportTip}
+                    >
+                        <i
+                            disabled={!songName.length}
+                            className="fa fa-download"
+                            aria-hidden="true"
+                        />
                     </button>
                     <button onClick={ this.loadJSON }>load</button>
                     <button onClick={ this.toggleShowCode }>
@@ -113,9 +136,6 @@ class SongEditor extends Component {
                     </button>
                 </h5>
                 
-                {/* <button onClick={ this.exportSong }>Export song</button>
-                <button onClick={ this.saveJSON }>save</button>
-                <button onClick={ this.loadJSON }>load</button> */}
                 <div className="song-editor-controls">
                     <button onClick={ this[playOrStop] }>
                         {`${playOrStopText}`} Song
@@ -129,7 +149,6 @@ class SongEditor extends Component {
                     </label>
                     <div style={{flex: 1}}></div>
                     <button onClick={this.toggleMute}>{ `${state.isMuted ? 'un' : ''}mute` }</button>
-                    {/* <button onClick={ this.toggleShowCode }>{ `${state.showCode ? 'Hide' : 'Show'} code` }</button> */}
                 </div>
 
                 <div className="song-editor-channels">

--- a/src/js/components/editor/trackEditor/TrackEditorView.js
+++ b/src/js/components/editor/trackEditor/TrackEditorView.js
@@ -167,7 +167,7 @@ class TrackEditor extends Component {
                     <form className="editor-info-row" onSubmit={ this.changeTicksAmount }>
                         <label htmlFor="track-ticks">Ticks: </label>
                         <input id="track-ticks" onChange={this.trackTicksAmount} type="number" min="1" max="64" value={state.currentTicks || 0} />
-                        <input type="submit" value="apply" />
+                        <input type="submit" value="ok" />
                     </form>
                 </div>
 

--- a/src/js/components/player/Player.js
+++ b/src/js/components/player/Player.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import PlayerView from './PlayerView'
 
 const mapStateToProps = (state) => {
-    const { channels, tracks, fx, activeTrack,
+    const { channels, tracks, fx, activeTrack, songName,
           activeTrackType, songRepeat, trackRepeat } = state
     return {
         channels,
@@ -10,6 +10,7 @@ const mapStateToProps = (state) => {
         fx,
         activeTrack,
         activeTrackType,
+        songName,
         songRepeat,
         trackRepeat
     }

--- a/src/js/components/player/PlayerView.js
+++ b/src/js/components/player/PlayerView.js
@@ -317,12 +317,12 @@ class Player extends Component {
     }
 
     getSongFileCode = () => {
-        const { tracks, channels, fx } = this.props
+        const { channels, fx, songName, tracks } = this.props
 
         return createSongFileFromChannels(
             Object.assign(
                 {},
-                { tracks, channels, fx }
+                { channels, fx, songName, tracks }
             )
         )
     }

--- a/src/js/reducers/reducer.js
+++ b/src/js/reducers/reducer.js
@@ -5,6 +5,7 @@ import channels from './channels'
 import fx from './fx'
 import song from './song'
 import songIsPlaying from './songIsPlaying'
+import songName from './songName'
 import songRepeat from './songRepeat'
 import status from './status'
 import trackIsPlaying from './tracks/trackIsPlaying'
@@ -18,6 +19,7 @@ export default combineReducers({
     fx,
     song,
     songIsPlaying,
+    songName,
     songRepeat,
     status,
     trackIsPlaying,

--- a/src/js/reducers/songName.js
+++ b/src/js/reducers/songName.js
@@ -1,0 +1,10 @@
+import sanitize from 'sanitize-filename';
+const defaultState = ''
+
+export default function songName (state = defaultState, action) {
+    switch (action.type) {
+        case 'SET_SONG_NAME': return sanitize(action.songName)
+
+        default: return state
+    }
+}


### PR DESCRIPTION
There is an input field for the file name at the top.  There's no restrictions, but it will normalize input before saving the file name to the tracker or .h file.  We can back that sanitizing action up to user input if need be, but for now it'll just strip slashes and stuff before trying to add the song name as the file name in the download name or use it in the songName variables in the .h output.

The save / export buttons are disabled and grayed out unless you have a file name (loading a tracker file will look for a meta.name entry and if it's not there it'll use the file name itself).  Hovering over the buttons while the field is empty will prompt the user for a song name.  Once filled each button's tooltip will say what the file name is that the button action will save / export as.

This addresses issue: https://github.com/ModusCreateOrg/trackerEditor/issues/8